### PR TITLE
리터럴 - Literals

### DIFF
--- a/thymeleaf-basic/src/main/java/hello/thymeleaf/basic/BasicController.java
+++ b/thymeleaf-basic/src/main/java/hello/thymeleaf/basic/BasicController.java
@@ -89,4 +89,10 @@ public class BasicController {
         return "basic/link";
     }
 
+    @GetMapping("/literal")
+    public String literal(Model model) {
+        model.addAttribute("data", "spring!");
+        return "basic/literal";
+    }
+
 }

--- a/thymeleaf-basic/src/main/resources/templates/basic/literal.html
+++ b/thymeleaf-basic/src/main/resources/templates/basic/literal.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+<h1>리터럴</h1>
+<ul>
+    <!--주의! 다음 주석을 풀면 예외가 발생함-->
+    <!-- <li>"hello world!" = <span th:text="hello world!"></span></li>-->
+    <li>'hello' + ' world!' = <span th:text="'hello' + ' world!'"></span></li>
+    <li>'hello world!' = <span th:text="'hello world!'"></span></li>
+    <li>'hello ' + ${data} = <span th:text="'hello ' + ${data}"></span></li>
+    <li>리터럴 대체 |hello ${data}| = <span th:text="|hello ${data}|"></span></li>
+</ul>
+</body>
+</html>


### PR DESCRIPTION
오류
<span th:text="hello world!"></span>
문자 리터럴은 원칙상 ' 로 감싸야 한다. 중간에 공백이 있어서 하나의 의미있는 토큰으로도 인식되지
않는다.
수정
<span th:text="'hello world!'"></span>
이렇게 ' 로 감싸면 정상 동작한다.

리터럴 대체(Literal substitutions)
<span th:text="|hello ${data}|">
마지막의 리터럴 대체 문법을 사용하면 마치 템플릿을 사용하는 것 처럼 편리하다.