### PR TITLE
템플릿 조각

### DIFF
--- a/thymeleaf-basic/src/main/java/hello/thymeleaf/basic/TemplateController.java
+++ b/thymeleaf-basic/src/main/java/hello/thymeleaf/basic/TemplateController.java
@@ -1,0 +1,15 @@
+package hello.thymeleaf.basic;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/template")
+public class TemplateController {
+
+    @GetMapping("/fragment")
+    public String template() {
+        return "template/fragment/fragmentMain";
+    }
+}

--- a/thymeleaf-basic/src/main/resources/templates/template/fragment/footer.html
+++ b/thymeleaf-basic/src/main/resources/templates/template/fragment/footer.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<footer th:fragment="copy">
+    푸터 자리 입니다.
+</footer>
+<footer th:fragment="copyParam (param1, param2)">
+    <p>파라미터 자리 입니다.</p>
+    <p th:text="${param1}"></p>
+    <p th:text="${param2}"></p>
+</footer>
+</body>
+</html>

--- a/thymeleaf-basic/src/main/resources/templates/template/fragment/fragmentMain.html
+++ b/thymeleaf-basic/src/main/resources/templates/template/fragment/fragmentMain.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+<h1>부분 포함</h1>
+<h2>부분 포함 insert</h2>
+<div th:insert="~{template/fragment/footer :: copy}"></div>
+<h2>부분 포함 replace</h2>
+<div th:replace="~{template/fragment/footer :: copy}"></div>
+<h2>부분 포함 단순 표현식</h2>
+<div th:replace="template/fragment/footer :: copy"></div>
+<h1>파라미터 사용</h1>
+<div th:replace="~{template/fragment/footer :: copyParam ('데이터1', '데이터2')}"></div>


### PR DESCRIPTION
웹 페이지를 개발할 때는 공통 영역이 많이 있다. 예를 들어서 상단 영역이나 하단 영역, 좌측 카테고리 등등
여러 페이지에서 함께 사용하는 영역들이 있다. 이런 부분을 코드를 복사해서 사용한다면 변경시 여러
페이지를 다 수정해야 하므로 상당히 비효율 적이다. 타임리프는 이런 문제를 해결하기 위해 템플릿 조각과
레이아웃 기능을 지원한다.


- template/fragment/footer :: copy : template/fragment/footer.html 템플릿에 있는
th:fragment="copy" 라는 부분을 템플릿 조각으로 가져와서 사용한다는 의미이다.

- 부분 포함 replace
<div th:replace="~{template/fragment/footer :: copy}"></div>

- 부분 포함 단순 표현식
<div th:replace="template/fragment/footer :: copy"></div>

- 파라미터 사용
다음과 같이 파라미터를 전달해서 동적으로 조각을 렌더링 할 수도 있다.
<div th:replace="~{template/fragment/footer :: copyParam ('데이터1', '데이터2')}"></
div>